### PR TITLE
Resolves #16 VTX "[Vortex] Add deployed field inside contract"

### DIFF
--- a/_sources/sources/contracts/contracts.actions.ts
+++ b/_sources/sources/contracts/contracts.actions.ts
@@ -176,4 +176,17 @@ export function ContractCompleteRefresh(contract_name: string, contract_address:
     } as ContractCompleteRefreshAction;
 }
 
-export type ContractActions = ContractLoadingAction | ContractLoadedAction | ContractErrorAction | ContractCallAction | ContractSendAction | ContractVarReceivedAction | ContractVarErrorReceivedAction | ContractVarForceRefreshAction;
+export interface ContractSetDeployedAction extends Action {
+    contract_name: string,
+    contract_address: string
+}
+
+export function ContractSetDeployed(contract_name: string, contract_address: string): ContractSetDeployedAction {
+    return {
+        type: 'CONTRACT_SET_DEPLOYED',
+        contract_name,
+        contract_address
+    } as ContractSetDeployedAction;
+}
+
+export type ContractActions = ContractLoadingAction | ContractLoadedAction | ContractErrorAction | ContractCallAction | ContractSendAction | ContractVarReceivedAction | ContractVarErrorReceivedAction | ContractVarForceRefreshAction | ContractSetDeployedAction;

--- a/_sources/sources/contracts/contracts.reducers.ts
+++ b/_sources/sources/contracts/contracts.reducers.ts
@@ -4,7 +4,7 @@ import {
     ContractActions,
     ContractErrorAction,
     ContractLoadedAction,
-    ContractLoadingAction,
+    ContractLoadingAction, ContractSetDeployedAction,
     ContractVarErrorReceivedAction,
     ContractVarForceRefreshAction,
     ContractVarReceivedAction
@@ -14,7 +14,7 @@ const contractLoadingReducer: Reducer<ContractStoreState, ContractLoadingAction>
     return {
         ...state,
         [action.contractName]: {
-            ...state[action.contractName],
+            ...(<Object>state)[action.contractName],
             [action.contractAddress.toLowerCase()]: {
                 ...state[action.contractName][action.contractAddress.toLowerCase()],
                 status: 'LOADING',
@@ -29,7 +29,7 @@ const contractLoadedReducer: Reducer<ContractStoreState, ContractLoadedAction> =
     return {
         ...state,
         [action.contractName]: {
-            ...state[action.contractName],
+            ...(<Object>state)[action.contractName],
             [action.contractAddress.toLowerCase()]: {
                 ...state[action.contractName][action.contractAddress.toLowerCase()],
                 status: 'LOADED',
@@ -44,7 +44,7 @@ const contractErrorReducer: Reducer<ContractStoreState, ContractErrorAction> = (
     return {
         ...state,
         [action.contractName]: {
-            ...state[action.contractName],
+            ...(<Object>state)[action.contractName],
             [action.contractAddress.toLowerCase()]: {
                 ...state[action.contractName][action.contractAddress.toLowerCase()],
                 status: 'ERROR',
@@ -58,7 +58,7 @@ const contractVarReceivedReducer: Reducer<ContractStoreState, ContractVarReceive
     return {
         ...state,
         [action.contractName]: {
-            ...state[action.contractName],
+            ...(<Object>state)[action.contractName],
             [action.contractAddress.toLowerCase()]: {
                 ...state[action.contractName][action.contractAddress.toLowerCase()],
                 instance: {
@@ -86,7 +86,7 @@ const contractVarErrorReceivedReducer: Reducer<ContractStoreState, ContractVarEr
     return {
         ...state,
         [action.contractName]: {
-            ...state[action.contractName],
+            ...(<Object>state)[action.contractName],
             [action.contractAddress.toLowerCase()]: {
                 ...state[action.contractName][action.contractAddress.toLowerCase()],
                 instance: {
@@ -114,7 +114,7 @@ const contractVarForceRefreshReducer: Reducer<ContractStoreState, ContractVarFor
     return {
         ...state,
         [action.contractName]: {
-            ...state[action.contractName],
+            ...(<Object>state)[action.contractName],
             [action.contractAddress.toLowerCase()]: {
                 ...state[action.contractName][action.contractAddress.toLowerCase()],
                 instance: {
@@ -138,6 +138,16 @@ const contractVarForceRefreshReducer: Reducer<ContractStoreState, ContractVarFor
     };
 };
 
+const contractSetDeployedReducer: Reducer<ContractStoreState, ContractSetDeployedAction> = (state: ContractStoreState       , action: ContractSetDeployedAction): ContractStoreState => {
+    return {
+        ...state,
+        [action.contract_name]: {
+            ...(<Object>state)[action.contract_name],
+            deployed: action.contract_address.toLowerCase()
+        }
+    }
+};
+
 export const contracts: Reducer<ContractStoreState, ContractActions> = (state: ContractStoreState = {}, action: ContractActions): ContractStoreState => {
     switch (action.type) {
 
@@ -153,6 +163,8 @@ export const contracts: Reducer<ContractStoreState, ContractActions> = (state: C
             return contractVarErrorReceivedReducer(state, <ContractVarErrorReceivedAction>action);
         case 'CONTRACT_VAR_FORCE_REFRESH':
             return contractVarForceRefreshReducer(state, <ContractVarForceRefreshAction>action);
+        case 'CONTRACT_SET_DEPLOYED':
+            return contractSetDeployedReducer(state, <ContractSetDeployedAction>action);
 
         default:
             return state;

--- a/_sources/sources/contracts/contracts.saga.ts
+++ b/_sources/sources/contracts/contracts.saga.ts
@@ -13,7 +13,7 @@ import {
     ContractLoaded,
     ContractLoadInfos,
     ContractLoading, ContractPreloadDone,
-    ContractSendAction,
+    ContractSendAction, ContractSetDeployed,
     ContractVarErrorReceived,
     ContractVarForceRefresh,
     ContractVarReceived
@@ -134,6 +134,7 @@ function* onLoadContractInitialize(action: Web3LoadedAction): SagaIterator {
                             break;
                         }
                         yield* loadContract(contractNames[idx], contract_instance.networks[action.networkId].address.toLowerCase(), action.coinbase, action._);
+                        yield put(ContractSetDeployed(contractNames[idx], contract_instance.networks[action.networkId].address));
                         recap.push({name: contractNames[idx], address: contract_instance.networks[action.networkId].address.toLowerCase()});
                     }
                 }
@@ -151,6 +152,7 @@ function* onLoadContractInitialize(action: Web3LoadedAction): SagaIterator {
                     const infos = contract_infos[Object.keys(contract_infos)[idx]];
                     if (to_preload.indexOf(infos.name) !== -1 && contracts[infos.name]) {
                         yield* loadContract(infos.name, infos.address.toLowerCase(), action.coinbase, action._);
+                        yield put(ContractSetDeployed(infos.name, infos.address));
                         recap.push({name: infos.name, address: infos.address.toLowerCase()});
                     }
                 }
@@ -174,6 +176,7 @@ function* onLoadContractInitialize(action: Web3LoadedAction): SagaIterator {
                             }
                         }
                         yield* loadContract(Object.keys(config_contract)[idx], infos.at.toLowerCase(), action.coinbase, action._);
+                        yield put(ContractSetDeployed(Object.keys(config_contract)[idx], infos.at));
                         recap.push({name: Object.keys(config_contract)[idx], address: infos.at.toLowerCase()});
                     }
                 }

--- a/_sources/sources/propMappers.ts
+++ b/_sources/sources/propMappers.ts
@@ -22,10 +22,16 @@ const contractLoading = {};
  * @param {boolean} load Wether to load to contract or not if not found in store.
  * @returns {any} Returns undefined until the contract instance is found.
  */
-export const getContract = (state: State, contract_name: string, contract_address: string, load?: boolean): any => {
-    contract_address = contract_address.toLowerCase();
+export const getContract = (state: State, contract_name: string, contract_address?: string, load?: boolean): any => {
+    if (!contract_address) {
+        contract_address = (<Object>state.contracts)[contract_name].deployed.toLowercase();
+    } else {
+        contract_address = contract_address.toLowerCase();
+    }
     if (!state.contracts[contract_name])
         throw new Error("Unknown contract type " + contract_name);
+    if (!contract_address)
+        return undefined;
     if (!state.contracts[contract_name][contract_address] || !state.contracts[contract_name][contract_address].instance) {
         if (!contractLoading[contract_name + contract_address] && load) {
             Vortex.get().loadContract(contract_name, contract_address);

--- a/_sources/sources/stateInterface.ts
+++ b/_sources/sources/stateInterface.ts
@@ -93,7 +93,7 @@ export interface ContractArtifactState {
 }
 
 export interface ContractStoreState {
-    [key: string]: ContractAddressesState | ContractArtifactState;
+    [key: string]: ContractAddressesState | ContractArtifactState | string;
 }
 
 interface FeedHeader {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     ]
   },
   "dependencies": {
-    "@types/node": "^10.5.1",
     "bn.js": "^4.11.8",
     "ipfs-api": "^22.0.1",
     "is-ipfs": "^0.3.2",
@@ -40,6 +39,7 @@
     "web3-utils": "^1.0.0-beta.34"
   },
   "devDependencies": {
+    "@types/node": "^10.5.2",
     "embark": "^3.1.1",
     "ganache-core": "^2.1.2",
     "jest": "^22.4.3",


### PR DESCRIPTION
Add deployed entry in contracts

- deployed field contaisn address of automatically deployed contract
- getContract can be called without address and will return the deployed
instance

VTX #16